### PR TITLE
fix: corrige atribuição undefined para variável de contexto

### DIFF
--- a/src/lib/classes/Context.js
+++ b/src/lib/classes/Context.js
@@ -150,8 +150,10 @@ export class Context {
     const _name = new VariableName(name);
 
     if (expiration < 0) throw new NegativeExpirationError();
-    if (value === undefined)
+    if (value === undefined) {
       this.#repository.set(_name.toString(), {}, expiration);
+      return;
+    }
 
     this.#repository.set(_name.toString(), value, expiration);
   }


### PR DESCRIPTION
Corrige atribuição de undefined para variável de contexto quando nenhum valor é fornecido.